### PR TITLE
feat: Publishes change event from CardVerificationCodeElement on brand changes

### DIFF
--- a/lib/src/main/java/com/basistheory/android/view/TextElement.kt
+++ b/lib/src/main/java/com/basistheory/android/view/TextElement.kt
@@ -215,6 +215,9 @@ open class TextElement @JvmOverloads constructor(
         isInternalChange = false
     }
 
+    protected fun publishChangeEvent()
+        = publishChangeEvent(editText.editableText)
+
     private fun publishChangeEvent(editable: Editable?) {
         val event = createElementChangeEvent(
             getText(),

--- a/lib/src/main/java/com/basistheory/android/view/mask/ElementMask.kt
+++ b/lib/src/main/java/com/basistheory/android/view/mask/ElementMask.kt
@@ -16,6 +16,9 @@ class ElementMask {
         )
     }
 
+    val length: Int
+        get() = characterMasks.size
+
     internal fun evaluate(text: String?, action: InputAction): String? {
         if (text.isNullOrEmpty())
             return ""

--- a/lib/src/test/java/com/basistheory/android/view/CardVerificationCodeElementTests.kt
+++ b/lib/src/test/java/com/basistheory/android/view/CardVerificationCodeElementTests.kt
@@ -100,8 +100,8 @@ class CardVerificationCodeElementTests {
         val changeEvents = mutableListOf<ChangeEvent>()
         cvcElement.addChangeEventListener { changeEvents.add(it) }
 
-        cvcElement.cardNumberElement = cardNumberElement
         cardNumberElement.setText("4242424242424242")
+        cvcElement.cardNumberElement = cardNumberElement
         cvcElement.setText("123")
 
         expectThat(changeEvents).single().and {
@@ -126,8 +126,8 @@ class CardVerificationCodeElementTests {
         val changeEvents = mutableListOf<ChangeEvent>()
         cvcElement.addChangeEventListener { changeEvents.add(it) }
 
-        cvcElement.cardNumberElement = cardNumberElement
         cardNumberElement.setText("378282246310005")
+        cvcElement.cardNumberElement = cardNumberElement
         cvcElement.setText("1234")
 
         expectThat(changeEvents).single().and {
@@ -152,8 +152,8 @@ class CardVerificationCodeElementTests {
         val changeEvents = mutableListOf<ChangeEvent>()
         cvcElement.addChangeEventListener { changeEvents.add(it) }
 
-        cvcElement.cardNumberElement = cardNumberElement
         cardNumberElement.setText("4242424242424242")
+        cvcElement.cardNumberElement = cardNumberElement
         cvcElement.setText("1234")
 
         expectThat(changeEvents).single().and {

--- a/lib/src/test/java/com/basistheory/android/view/CardVerificationCodeElementTests.kt
+++ b/lib/src/test/java/com/basistheory/android/view/CardVerificationCodeElementTests.kt
@@ -122,7 +122,7 @@ class CardVerificationCodeElementTests {
     }
 
     @Test
-    fun `emits a change event when mask increases from 4 to 3 chars`() {
+    fun `emits a change event when mask decreases from 4 to 3 chars`() {
         val changeEvents = mutableListOf<ChangeEvent>()
         cvcElement.addChangeEventListener { changeEvents.add(it) }
 


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

When the card number is changed resulting in a card brand change with a different mask length, we now emit an additional event from the the CVC element with updated validation/completion states.

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
