### PR TITLE
feat: Replace and prefix custom attributes to prevent collisions

### DIFF
--- a/example/src/main/res/layout/fragment_card.xml
+++ b/example/src/main/res/layout/fragment_card.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:bt="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
@@ -34,9 +33,8 @@
                     android:layout_height="wrap_content"
                     android:background="@drawable/rounded_edit_text"
                     android:padding="5dp"
-                    bt:hint="Card Number"
-                    bt:removeDefaultStyles="true"
-                    bt:textColor="@{ viewModel.cardNumber.isInvalid ? @color/red : @color/gray_800 }" />
+                    android:hint="@string/card_number"
+                    android:textColor="@{ viewModel.cardNumber.isInvalid ? @color/red : @color/gray_800 }" />
 
                 <com.basistheory.android.view.CardExpirationDateElement
                     android:id="@+id/expiration_date"
@@ -45,9 +43,8 @@
                     android:layout_marginTop="20dp"
                     android:background="@drawable/rounded_edit_text"
                     android:padding="5dp"
-                    bt:hint="Expiration Date"
-                    bt:removeDefaultStyles="true"
-                    bt:textColor="@{ viewModel.cardExpiration.isInvalid ? @color/red : @color/gray_800 }" />
+                    android:hint="@string/expiration_date"
+                    android:textColor="@{ viewModel.cardExpiration.isInvalid ? @color/red : @color/gray_800 }" />
 
                 <com.basistheory.android.view.CardVerificationCodeElement
                     android:id="@+id/cvc"
@@ -56,9 +53,8 @@
                     android:layout_marginTop="20dp"
                     android:background="@drawable/rounded_edit_text"
                     android:padding="5dp"
-                    bt:hint="CVC"
-                    bt:removeDefaultStyles="true"
-                    bt:textColor="@{ viewModel.cardCvc.isInvalid ? @color/red : @color/gray_800 }" />
+                    android:hint="@string/cvc"
+                    android:textColor="@{ viewModel.cardCvc.isInvalid ? @color/red : @color/gray_800 }" />
 
                 <LinearLayout
                     android:layout_width="wrap_content"

--- a/example/src/main/res/layout/fragment_custom_form.xml
+++ b/example/src/main/res/layout/fragment_custom_form.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:bt="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
@@ -32,9 +31,8 @@
                     android:layout_height="wrap_content"
                     android:background="@drawable/rounded_edit_text"
                     android:padding="5dp"
-                    bt:hint="Name"
-                    bt:removeDefaultStyles="true"
-                    bt:textColor="@color/gray_800" />
+                    android:hint="@string/name"
+                    android:textColor="@color/gray_800" />
 
                 <com.basistheory.android.view.TextElement
                     android:id="@+id/phoneNumber"
@@ -43,9 +41,8 @@
                     android:layout_marginTop="20dp"
                     android:background="@drawable/rounded_edit_text"
                     android:padding="5dp"
-                    bt:hint="Phone Number"
-                    bt:removeDefaultStyles="true"
-                    bt:textColor="@color/gray_800" />
+                    android:hint="@string/phone_number"
+                    android:textColor="@color/gray_800" />
 
                 <com.basistheory.android.view.TextElement
                     android:id="@+id/orderNumber"
@@ -54,10 +51,9 @@
                     android:layout_marginTop="20dp"
                     android:background="@drawable/rounded_edit_text"
                     android:padding="5dp"
-                    bt:hint="Order Number"
-                    bt:inputType="text"
-                    bt:removeDefaultStyles="true"
-                    bt:textColor="@color/gray_800" />
+                    android:hint="@string/order_number"
+                    android:inputType="text"
+                    android:textColor="@color/gray_800" />
 
                 <com.basistheory.android.view.TextElement
                     android:id="@+id/password"
@@ -66,10 +62,9 @@
                     android:layout_marginTop="20dp"
                     android:background="@drawable/rounded_edit_text"
                     android:padding="5dp"
-                    bt:hint="Password"
-                    bt:inputType="textPassword"
-                    bt:removeDefaultStyles="true"
-                    bt:textColor="@color/gray_800" />
+                    android:hint="@string/password"
+                    android:inputType="textPassword"
+                    android:textColor="@color/gray_800" />
 
                 <com.basistheory.android.view.TextElement
                     android:id="@+id/pin"
@@ -78,10 +73,9 @@
                     android:layout_marginTop="20dp"
                     android:background="@drawable/rounded_edit_text"
                     android:padding="5dp"
-                    bt:hint="PIN"
-                    bt:inputType="numberPassword"
-                    bt:removeDefaultStyles="true"
-                    bt:textColor="@color/gray_800" />
+                    android:hint="@string/pin"
+                    android:inputType="numberPassword"
+                    android:textColor="@color/gray_800" />
 
                 <LinearLayout
                     android:layout_width="wrap_content"

--- a/example/src/main/res/layout/fragment_reveal.xml
+++ b/example/src/main/res/layout/fragment_reveal.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:bt="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
@@ -34,10 +33,9 @@
                     android:layout_height="wrap_content"
                     android:background="@drawable/rounded_edit_text"
                     android:padding="5dp"
-                    bt:editable="false"
-                    bt:hint="Revealed Card Number"
-                    bt:removeDefaultStyles="true"
-                    bt:textColor="@color/gray_800" />
+                    android:enabled="false"
+                    android:hint="@string/revealed_card_number"
+                    android:textColor="@color/gray_800" />
 
                 <com.basistheory.android.view.CardExpirationDateElement
                     android:id="@+id/revealedExpirationDate"
@@ -46,10 +44,9 @@
                     android:layout_marginTop="20dp"
                     android:background="@drawable/rounded_edit_text"
                     android:padding="5dp"
-                    bt:editable="false"
-                    bt:hint="Revealed Expiration Date"
-                    bt:removeDefaultStyles="true"
-                    bt:textColor="@color/gray_800" />
+                    android:enabled="false"
+                    android:hint="@string/revealed_expiration_date"
+                    android:textColor="@color/gray_800" />
 
                 <com.basistheory.android.view.CardVerificationCodeElement
                     android:id="@+id/revealedCvc"
@@ -58,10 +55,9 @@
                     android:layout_marginTop="20dp"
                     android:background="@drawable/rounded_edit_text"
                     android:padding="5dp"
-                    bt:editable="false"
-                    bt:hint="Revealed CVC"
-                    bt:removeDefaultStyles="true"
-                    bt:textColor="@color/gray_800" />
+                    android:enabled="false"
+                    android:hint="@string/revealed_cvc"
+                    android:textColor="@color/gray_800" />
 
                 <com.basistheory.android.view.CardNumberElement
                     android:id="@+id/card_number"
@@ -70,9 +66,8 @@
                     android:layout_marginTop="20dp"
                     android:background="@drawable/rounded_edit_text"
                     android:padding="5dp"
-                    bt:hint="Card Number"
-                    bt:removeDefaultStyles="true"
-                    bt:textColor="@{ viewModel.cardNumber.isInvalid ? @color/red : @color/gray_800 }" />
+                    android:hint="@string/card_number"
+                    android:textColor="@{ viewModel.cardNumber.isInvalid ? @color/red : @color/gray_800 }" />
 
                 <com.basistheory.android.view.CardExpirationDateElement
                     android:id="@+id/expiration_date"
@@ -81,9 +76,8 @@
                     android:layout_marginTop="20dp"
                     android:background="@drawable/rounded_edit_text"
                     android:padding="5dp"
-                    bt:hint="Expiration Date"
-                    bt:removeDefaultStyles="true"
-                    bt:textColor="@{ viewModel.cardExpiration.isInvalid ? @color/red : @color/gray_800 }" />
+                    android:hint="@string/expiration_date"
+                    android:textColor="@{ viewModel.cardExpiration.isInvalid ? @color/red : @color/gray_800 }" />
 
                 <com.basistheory.android.view.CardVerificationCodeElement
                     android:id="@+id/cvc"
@@ -92,9 +86,8 @@
                     android:layout_marginTop="20dp"
                     android:background="@drawable/rounded_edit_text"
                     android:padding="5dp"
-                    bt:hint="CVC"
-                    bt:removeDefaultStyles="true"
-                    bt:textColor="@{ viewModel.cardCvc.isInvalid ? @color/red : @color/gray_800 }" />
+                    android:hint="@string/cvc"
+                    android:textColor="@{ viewModel.cardCvc.isInvalid ? @color/red : @color/gray_800 }" />
 
                 <LinearLayout
                     android:layout_width="wrap_content"

--- a/example/src/main/res/layout/fragment_social_security_number.xml
+++ b/example/src/main/res/layout/fragment_social_security_number.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:bt="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
@@ -33,11 +33,9 @@
                     android:background="@drawable/rounded_edit_text"
                     android:inputType="number"
                     android:padding="5dp"
-                    bt:hint="Social Security Number"
-                    bt:inputType="number"
-                    bt:mask="###-##-####"
-                    bt:removeDefaultStyles="true"
-                    bt:textColor="@color/gray_800" />
+                    android:hint="@string/social_security_number"
+                    android:textColor="@color/gray_800"
+                    app:bt_mask="###-##-####" />
 
                 <LinearLayout
                     android:layout_width="wrap_content"

--- a/example/src/main/res/layout/fragment_styling.xml
+++ b/example/src/main/res/layout/fragment_styling.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:bt="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
@@ -34,18 +34,18 @@
                     android:layout_height="wrap_content"
                     android:padding="5dp"
                     android:layout_marginBottom="20dp"
-                    bt:removeDefaultStyles="false"
-                    bt:hint="Name" />
+                    android:hint="@string/name"
+                    app:bt_removeDefaultStyles="false" />
 
                 <com.basistheory.android.view.TextElement
                     android:id="@+id/socialSecurityNumber"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:padding="5dp"
-                    bt:removeDefaultStyles="false"
-                    bt:inputType="number"
-                    bt:mask="###-##-####"
-                    bt:hint="Social Security Number" />
+                    android:hint="@string/social_security_number"
+                    android:inputType="number"
+                    app:bt_removeDefaultStyles="false"
+                    app:bt_mask="###-##-####" />
 
                 <LinearLayout
                     android:layout_width="wrap_content"

--- a/example/src/main/res/layout/fragment_virtual_card.xml
+++ b/example/src/main/res/layout/fragment_virtual_card.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:bt="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -34,22 +33,20 @@
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_horizontal"
                         android:layout_marginTop="40dp"
-                        bt:text="0000 0000 0000 0000"
-                        bt:textColor="@color/white"
-                        bt:textSize="20sp"
-                        bt:editable="false"
-                        bt:removeDefaultStyles="true" />
+                        android:text="0000 0000 0000 0000"
+                        android:textColor="@color/white"
+                        android:textSize="20sp"
+                        android:enabled="false" />
 
                     <com.basistheory.android.view.TextElement
                         android:id="@+id/readonly_expiration_date"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginVertical="10dp"
-                        bt:text="**/**"
-                        bt:textColor="@color/white"
-                        bt:textSize="14sp"
-                        bt:editable="false"
-                        bt:removeDefaultStyles="true" />
+                        android:text="**/**"
+                        android:textColor="@color/white"
+                        android:textSize="14sp"
+                        android:enabled="false" />
 
                 </LinearLayout>
 
@@ -60,9 +57,8 @@
                     android:background="@drawable/rounded_edit_text"
                     android:padding="5dp"
                     android:layout_marginTop="20dp"
-                    bt:hint="Card Number"
-                    bt:removeDefaultStyles="true"
-                    bt:textColor="@color/gray_800" />
+                    android:hint="@string/card_number"
+                    android:textColor="@color/gray_800" />
 
                 <com.basistheory.android.view.CardExpirationDateElement
                     android:id="@+id/expiration_date"
@@ -71,9 +67,8 @@
                     android:layout_marginTop="20dp"
                     android:background="@drawable/rounded_edit_text"
                     android:padding="5dp"
-                    bt:hint="Expiration Date"
-                    bt:removeDefaultStyles="true"
-                    bt:textColor="@color/gray_800" />
+                    android:hint="@string/expiration_date"
+                    android:textColor="@color/gray_800" />
 
                 <com.basistheory.android.view.CardVerificationCodeElement
                     android:id="@+id/cvc"
@@ -82,9 +77,8 @@
                     android:layout_marginTop="20dp"
                     android:background="@drawable/rounded_edit_text"
                     android:padding="5dp"
-                    bt:hint="CVC"
-                    bt:removeDefaultStyles="true"
-                    bt:textColor="@color/gray_800" />
+                    android:hint="@string/cvc"
+                    android:textColor="@color/gray_800" />
 
             </LinearLayout>
 

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -17,4 +17,16 @@
     <string name="reset">Reset</string>
     <string name="style1">Style 1</string>
     <string name="style2">Style 2</string>
+    <string name="name">Name</string>
+    <string name="social_security_number">Social Security Number</string>
+    <string name="card_number">Card Number</string>
+    <string name="expiration_date">Expiration Date</string>
+    <string name="cvc">CVC</string>
+    <string name="revealed_card_number">Revealed Card Number</string>
+    <string name="revealed_expiration_date">Revealed Expiration Date</string>
+    <string name="revealed_cvc">Revealed CVC</string>
+    <string name="order_number">Order Number</string>
+    <string name="password">Password</string>
+    <string name="phone_number">Phone Number</string>
+    <string name="pin">PIN</string>
 </resources>

--- a/lib/src/main/java/com/basistheory/android/model/InputType.kt
+++ b/lib/src/main/java/com/basistheory/android/model/InputType.kt
@@ -2,9 +2,29 @@ package com.basistheory.android.model
 
 import android.text.InputType as AndroidInputType
 
-enum class InputType(val androidInputType: Int, val isConcealed: Boolean = false) {
-    TEXT(AndroidInputType.TYPE_CLASS_TEXT),
-    NUMBER(AndroidInputType.TYPE_CLASS_NUMBER),
-    TEXT_PASSWORD(AndroidInputType.TYPE_TEXT_VARIATION_PASSWORD, true),
-    NUMBER_PASSWORD(AndroidInputType.TYPE_CLASS_NUMBER, true);
+enum class InputType(val attributeValue: Int, val androidInputType: Int, val isConcealed: Boolean = false) {
+    TEXT(
+        AndroidInputType.TYPE_CLASS_TEXT,
+        AndroidInputType.TYPE_CLASS_TEXT
+    ),
+    NUMBER(
+        AndroidInputType.TYPE_CLASS_NUMBER,
+        AndroidInputType.TYPE_CLASS_NUMBER
+    ),
+    TEXT_PASSWORD(
+        AndroidInputType.TYPE_CLASS_TEXT or AndroidInputType.TYPE_TEXT_VARIATION_PASSWORD,
+        AndroidInputType.TYPE_TEXT_VARIATION_PASSWORD,
+        true
+    ),
+    NUMBER_PASSWORD(
+        AndroidInputType.TYPE_CLASS_NUMBER or AndroidInputType.TYPE_NUMBER_VARIATION_PASSWORD,
+        AndroidInputType.TYPE_CLASS_NUMBER,
+        true
+    );
+
+    companion object {
+        fun fromAndroidAttr(androidAttrValue: Int): InputType =
+            InputType.values().find { it.attributeValue == androidAttrValue }
+                ?: throw IllegalArgumentException("Unknown input type '${androidAttrValue}'")
+    }
 }

--- a/lib/src/main/java/com/basistheory/android/view/TextElement.kt
+++ b/lib/src/main/java/com/basistheory/android/view/TextElement.kt
@@ -55,48 +55,6 @@ open class TextElement @JvmOverloads constructor(
         )
         super.addView(_editText)
 
-        val androidAttributes = arrayOf(
-            android.R.attr.hint,
-            android.R.attr.inputType,
-            android.R.attr.enabled,
-            android.R.attr.text,
-            android.R.attr.textColor,
-            android.R.attr.textSize,
-            android.R.attr.textColorHint,
-            android.R.attr.typeface
-        ).toIntArray()
-
-        // wire up standard android attributes
-        context.theme.obtainStyledAttributes(attrs, androidAttributes, defStyleAttr, 0)
-            .apply {
-                try {
-                    hint = getString(0)
-
-                    inputType = InputType.fromAndroidAttr(
-                        getInt(1, android.text.InputType.TYPE_CLASS_TEXT)
-                    )
-
-                    // todo: rename isEditable -> enabled?
-                    isEditable = getBoolean(2, true)
-
-                    setText(getString(3))
-
-                    textColor = getColor(4, Color.BLACK)
-
-                    textSize = getDimension(5, 16f * resources.displayMetrics.scaledDensity)
-
-                    // todo: rename hintTextColor -> textColorHint
-                    hintTextColor = getColor(6, Color.LTGRAY)
-
-                    typeface = resolveTypeface(
-                        getInt(7, 0),
-                        defStyleAttr
-                    )
-                } finally {
-                    recycle()
-                }
-            }
-
         // wire up custom attributes
         context.theme.obtainStyledAttributes(attrs, R.styleable.TextElement, defStyleAttr, 0)
             .apply {
@@ -111,7 +69,6 @@ open class TextElement @JvmOverloads constructor(
                         )
                     )
 
-                    // todo: rename isEditable -> enabled?
                     isEditable = getBoolean(R.styleable.TextElement_android_enabled, true)
 
                     setText(getString(R.styleable.TextElement_android_text))
@@ -120,7 +77,6 @@ open class TextElement @JvmOverloads constructor(
 
                     textSize = getDimension(R.styleable.TextElement_android_textSize, 16f * resources.displayMetrics.scaledDensity)
 
-                    // todo: rename hintTextColor -> textColorHint
                     hintTextColor = getColor(R.styleable.TextElement_android_textColorHint, Color.LTGRAY)
 
                     typeface = resolveTypeface(

--- a/lib/src/main/java/com/basistheory/android/view/TextElement.kt
+++ b/lib/src/main/java/com/basistheory/android/view/TextElement.kt
@@ -1,9 +1,9 @@
 package com.basistheory.android.view
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Color
 import android.graphics.Typeface
-import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.os.Parcelable
 import android.text.Editable
@@ -30,6 +30,7 @@ import com.basistheory.android.view.method.FullyHiddenTransformationMethod
 import com.basistheory.android.view.transform.ElementTransform
 import com.basistheory.android.view.validation.ElementValidator
 
+@SuppressLint("ResourceType")
 open class TextElement @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
@@ -54,48 +55,85 @@ open class TextElement @JvmOverloads constructor(
         )
         super.addView(_editText)
 
-        // wires up attributes declared in the xml layout with properties on this element
+        val androidAttributes = arrayOf(
+            android.R.attr.hint,
+            android.R.attr.inputType,
+            android.R.attr.enabled,
+            android.R.attr.text,
+            android.R.attr.textColor,
+            android.R.attr.textSize,
+            android.R.attr.textColorHint,
+            android.R.attr.typeface
+        ).toIntArray()
+
+        // wire up standard android attributes
+        context.theme.obtainStyledAttributes(attrs, androidAttributes, defStyleAttr, 0)
+            .apply {
+                try {
+                    hint = getString(0)
+
+                    inputType = InputType.fromAndroidAttr(
+                        getInt(1, android.text.InputType.TYPE_CLASS_TEXT)
+                    )
+
+                    // todo: rename isEditable -> enabled?
+                    isEditable = getBoolean(2, true)
+
+                    setText(getString(3))
+
+                    textColor = getColor(4, Color.BLACK)
+
+                    textSize = getDimension(5, 16f * resources.displayMetrics.scaledDensity)
+
+                    // todo: rename hintTextColor -> textColorHint
+                    hintTextColor = getColor(6, Color.LTGRAY)
+
+                    typeface = resolveTypeface(
+                        getInt(7, 0),
+                        defStyleAttr
+                    )
+                } finally {
+                    recycle()
+                }
+            }
+
+        // wire up custom attributes
         context.theme.obtainStyledAttributes(attrs, R.styleable.TextElement, defStyleAttr, 0)
             .apply {
                 try {
-                    isEditable = getBoolean(
-                        R.styleable.TextElement_editable,
-                        true
+                    // map standard android attributes
+                    hint = getString(R.styleable.TextElement_android_hint)
+
+                    inputType = InputType.fromAndroidAttr(
+                        getInt(
+                            R.styleable.TextElement_android_inputType,
+                            android.text.InputType.TYPE_CLASS_TEXT
+                        )
                     )
 
-                    hint = getString(R.styleable.TextElement_hint)
+                    // todo: rename isEditable -> enabled?
+                    isEditable = getBoolean(R.styleable.TextElement_android_enabled, true)
 
-                    inputType = InputType.values().elementAt(
-                        getInt(R.styleable.TextElement_inputType, 0)
-                    )
+                    setText(getString(R.styleable.TextElement_android_text))
 
-                    mask = getString(R.styleable.TextElement_mask)?.let { ElementMask(it) }
+                    textColor = getColor(R.styleable.TextElement_android_textColor, Color.BLACK)
 
-                    removeDefaultStyles = getBoolean(
-                        R.styleable.TextElement_removeDefaultStyles,
-                        true
-                    )
+                    textSize = getDimension(R.styleable.TextElement_android_textSize, 16f * resources.displayMetrics.scaledDensity)
 
-                    setText(getString(R.styleable.TextElement_text))
-
-                    textColor = getColor(
-                        R.styleable.TextElement_textColor,
-                        Color.BLACK
-                    )
-
-                    hintTextColor = getColor(
-                        R.styleable.TextElement_hintTextColor,
-                        Color.LTGRAY
-                    )
-
-                    textSize = getDimension(
-                        R.styleable.TextElement_textSize,
-                        16f * resources.displayMetrics.scaledDensity
-                    )
+                    // todo: rename hintTextColor -> textColorHint
+                    hintTextColor = getColor(R.styleable.TextElement_android_textColorHint, Color.LTGRAY)
 
                     typeface = resolveTypeface(
-                        getInt(R.styleable.TextElement_typeface, 0),
+                        getInt(R.styleable.TextElement_android_typeface, 0),
                         defStyleAttr
+                    )
+
+                    // map custom attributes
+                    mask = getString(R.styleable.TextElement_bt_mask)?.let { ElementMask(it) }
+
+                    removeDefaultStyles = getBoolean(
+                        R.styleable.TextElement_bt_removeDefaultStyles,
+                        true
                     )
                 } finally {
                     recycle()

--- a/lib/src/main/res/values/attrs.xml
+++ b/lib/src/main/res/values/attrs.xml
@@ -1,25 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="TextElement">
-        <attr name="editable" format="boolean" />
-        <attr name="hint" format="string" />
-        <attr name="inputType" format="enum">
-            <enum name="text" value="0" />
-            <enum name="number" value="1" />
-            <enum name="textPassword" value="2" />
-            <enum name="numberPassword" value="3" />
-        </attr>
-        <attr name="mask" format="string" />
-        <attr name="removeDefaultStyles" format="boolean" />
-        <attr name="text" format="string" />
-        <attr name="textColor" format="reference|color" />
-        <attr name="hintTextColor" format="reference|color" />
-        <attr name="textSize" format="dimension" />
-        <attr name="typeface">
-            <enum name="normal" value="0" />
-            <enum name="sans" value="1" />
-            <enum name="serif" value="2" />
-            <enum name="monospace" value="3" />
-        </attr>
+        <attr name="android:enabled" />
+        <attr name="android:hint" />
+        <attr name="android:inputType" />
+        <attr name="android:text" />
+        <attr name="android:textColor" />
+        <attr name="android:textSize" />
+        <attr name="android:textColorHint" />
+        <attr name="android:typeface" />
+
+        <attr name="bt_mask" format="string" />
+        <attr name="bt_removeDefaultStyles" format="boolean" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- BREAKING CHANGE: replaces custom xml attributes with android equivalents and prefixes custom attributes with `bt_`
- This addresses an issue where custom attributes can collide with other attributes declared in third party libraries

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
