### PR TITLE
fix: Mapping collections in proxy requests/responses to/from ElementValueReferences

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'org.threeten:threetenbp:1.6.8'
     implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.25'
-    implementation 'com.github.basis-theory:basistheory-java:0.4.0'
+    implementation 'com.github.basis-theory:basistheory-java:eng-4745-support-transactions-SNAPSHOT'
 
     androidTestImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.4'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'org.threeten:threetenbp:1.6.8'
     implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.25'
-    implementation 'com.github.basis-theory:basistheory-java:eng-4745-support-transactions-SNAPSHOT'
+    implementation 'com.github.basis-theory:basistheory-java:0.5.0'
 
     androidTestImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.4'

--- a/example/src/main/java/com/basistheory/android/example/view/raw_proxy_response/RawProxyResponseFragment.kt
+++ b/example/src/main/java/com/basistheory/android/example/view/raw_proxy_response/RawProxyResponseFragment.kt
@@ -43,6 +43,13 @@ class RawProxyResponseFragment : Fragment() {
             )
             body = object {
                 val text = binding.textElement
+                // echoed back in response to mimic proxy responses containing arrays
+                val array = arrayListOf<Any>(
+                    object {
+                        val id = 1
+                        val description = "value"
+                    }
+                )
             }
         }
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.threeten:threetenbp:1.6.8'
-    implementation 'com.github.basis-theory:basistheory-java:0.4.0'
+    implementation 'com.github.basis-theory:basistheory-java:eng-4745-support-transactions-SNAPSHOT'
     implementation 'com.squareup.okhttp3:okhttp:4.11.0'
     implementation 'com.google.code.gson:gson:2.10.1'
     testImplementation 'junit:junit:4.13.2'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.threeten:threetenbp:1.6.8'
-    implementation 'com.github.basis-theory:basistheory-java:eng-4745-support-transactions-SNAPSHOT'
+    implementation 'com.github.basis-theory:basistheory-java:0.5.0'
     implementation 'com.squareup.okhttp3:okhttp:4.11.0'
     implementation 'com.google.code.gson:gson:2.10.1'
     testImplementation 'junit:junit:4.13.2'

--- a/lib/src/main/java/com/basistheory/android/util/DataManipulationUtils.kt
+++ b/lib/src/main/java/com/basistheory/android/util/DataManipulationUtils.kt
@@ -9,6 +9,8 @@ fun transformResponseToValueReferences(data: Any?): Any? =
     else if (data::class.java.isPrimitiveType()) data.toString().toElementValueReference()
     else if (data::class.java.isArray) {
         (data as Array<*>).map { transformResponseToValueReferences(it) }
+    } else if (data is Collection<*>) {
+        data.map { transformResponseToValueReferences(it) }
     } else {
         val map = (data as Map<*, *>).toMutableMap()
         map.forEach { (key, value) -> map[key] = transformResponseToValueReferences(value) }
@@ -23,8 +25,15 @@ internal fun replaceElementRefs(value: Any?): Any? {
     else if (fieldType.isArray) {
         val array = value as Array<*>
         array.map {
-            it?.let { arrayValue ->
-                replaceElementRefs(arrayValue)
+            it?.let { item ->
+                replaceElementRefs(item)
+            }
+        }
+    }
+    else if (value is Collection<*>) {
+        value.map {
+            it?.let { item ->
+                replaceElementRefs(item)
             }
         }
     } else {

--- a/lib/src/test/java/com/basistheory/android/service/BasisTheoryElementsTests.kt
+++ b/lib/src/test/java/com/basistheory/android/service/BasisTheoryElementsTests.kt
@@ -305,6 +305,11 @@ class BasisTheoryElementsTests {
                         phoneNumberElement,
                         null
                     )
+                    val arrayList = arrayListOf(
+                        nameElement,
+                        phoneNumberElement,
+                        null
+                    )
                 }
             }
 
@@ -326,6 +331,11 @@ class BasisTheoryElementsTests {
                         "phoneNumber" to phoneNumber
                     ),
                     "array" to arrayListOf(
+                        name,
+                        phoneNumber,
+                        null
+                    ),
+                    "arrayList" to arrayListOf(
                         name,
                         phoneNumber,
                         null

--- a/lib/src/test/java/com/basistheory/android/service/ProxyApiTests.kt
+++ b/lib/src/test/java/com/basistheory/android/service/ProxyApiTests.kt
@@ -134,7 +134,12 @@ class ProxyApiTests {
                     "name" to linkedMapOf(
                         "first_name" to "Drewsue",
                         "last_name" to "Webuino"
-                    )
+                    ),
+                    "phone_numbers" to arrayListOf("+1 111 222 3333", "+1 999 888 7777"),
+                    "aliases" to arrayListOf(linkedMapOf(
+                        "first_name" to "John",
+                        "last_name" to "Doe"
+                    ))
                 )
             )
         )
@@ -154,6 +159,8 @@ class ProxyApiTests {
 
         expectThat(result.tryGetElementValueReference("pii.name.first_name")).isNotNull()
         expectThat(result.tryGetElementValueReference("pii.name.last_name")).isNotNull()
+        expectThat(result.tryGetElementValueReference("pii.phone_numbers[0]")).isNotNull()
+        expectThat(result.tryGetElementValueReference("pii.aliases[0].first_name")).isNotNull()
     }
 
     @Test
@@ -181,6 +188,30 @@ class ProxyApiTests {
             200,
             emptyMap(),
             arrayOf(
+                "foo",
+                null,
+                "bar",
+                null,
+                "yaz",
+                "qux"
+            )
+        )
+
+        val result = runBlocking {
+            proxyApi.post(proxyRequest)
+        }
+
+        expectThat(
+            (result as List<Any?>).filterNotNull().all { it is ElementValueReference }).isTrue()
+    }
+
+    @Test
+    fun `should transform array list proxy response to element value references`() {
+        val callSlot = slot<Call>()
+        every { apiClient.execute<Any>(capture(callSlot), any()) } returns ApiResponse(
+            200,
+            emptyMap(),
+            arrayListOf(
                 "foo",
                 null,
                 "bar",


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Proxy responses returning a json array are mapped into an ArrayList by the OkHttp3 client used by the Java SDK
- ArrayLists were not properly mapped to/from ElementValueReferences, only Array<*> were handled properly - `ArrayList<*>` is not considered an array but it does implement `Collection<*>`. `Array<*>` does not implement `Collection<*>` so we unfortunately need to maintain two separate explicit branches for Array vs Collection nodes in the proxy request and response.

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
