### PR TITLE
feat: add gravity attribute to TextElement

### DIFF
--- a/example/src/main/java/com/basistheory/android/example/view/custom_form/CustomFormFragment.kt
+++ b/example/src/main/java/com/basistheory/android/example/view/custom_form/CustomFormFragment.kt
@@ -1,6 +1,7 @@
 package com.basistheory.android.example.view.custom_form
 
 import android.os.Bundle
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -50,6 +51,8 @@ class CustomFormFragment : Fragment() {
                 digitRegex
             )
         )
+
+        binding.pin.gravity = Gravity.CENTER
 
         binding.orderNumber.mask = ElementMask(
             listOf(charRegex, charRegex, charRegex, "-", digitRegex, digitRegex, digitRegex)

--- a/lib/src/main/java/com/basistheory/android/view/TextElement.kt
+++ b/lib/src/main/java/com/basistheory/android/view/TextElement.kt
@@ -10,6 +10,7 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.util.AttributeSet
 import android.util.TypedValue
+import android.view.Gravity
 import android.view.View.OnFocusChangeListener
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
@@ -81,6 +82,8 @@ open class TextElement @JvmOverloads constructor(
                         getInt(R.styleable.TextElement_android_typeface, 0),
                         defStyleAttr
                     )
+
+                    gravity = Gravity.START
 
                     // map custom attributes
                     mask = getString(R.styleable.TextElement_bt_mask)?.let { ElementMask(it) }
@@ -176,6 +179,12 @@ open class TextElement @JvmOverloads constructor(
         get() = _editText.typeface
         set(value) {
             _editText.typeface = value
+        }
+
+    var gravity: Int
+        get() = _editText.gravity
+        set(value) {
+            _editText.gravity = value
         }
 
     var hint: CharSequence?

--- a/lib/src/main/res/values/attrs.xml
+++ b/lib/src/main/res/values/attrs.xml
@@ -9,6 +9,7 @@
         <attr name="android:textSize" />
         <attr name="android:textColorHint" />
         <attr name="android:typeface" />
+        <attr name="android:gravity" />
 
         <attr name="bt_mask" format="string" />
         <attr name="bt_removeDefaultStyles" format="boolean" />


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Forward the `android:gravity` attribute so users can align the text.

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

![image](https://github.com/Basis-Theory/basistheory-android/assets/9054729/a46dcd8b-20a8-45dd-92b2-d7b1d5509838)

- [ ] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
