### PR TITLE
feat: add type conversion when submitting element values

### DIFF
--- a/example/src/main/java/com/basistheory/android/example/view/custom_form/CustomFormFragment.kt
+++ b/example/src/main/java/com/basistheory/android/example/view/custom_form/CustomFormFragment.kt
@@ -1,6 +1,7 @@
 package com.basistheory.android.example.view.custom_form
 
 import android.os.Bundle
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -50,6 +51,8 @@ class CustomFormFragment : Fragment() {
                 digitRegex
             )
         )
+
+        binding.pin.gravity = Gravity.CENTER
 
         binding.orderNumber.mask = ElementMask(
             listOf(charRegex, charRegex, charRegex, "-", digitRegex, digitRegex, digitRegex)

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.2'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.threeten:threetenbp:1.6.8'
-    implementation 'com.github.basis-theory:basistheory-java:0.5.0'
+    implementation 'com.github.basis-theory:basistheory-java:1.0.0'
     implementation 'com.squareup.okhttp3:okhttp:4.11.0'
     implementation 'com.google.code.gson:gson:2.10.1'
     testImplementation 'junit:junit:4.13.2'

--- a/lib/src/main/java/com/basistheory/android/constants/ElementValueType.java
+++ b/lib/src/main/java/com/basistheory/android/constants/ElementValueType.java
@@ -1,0 +1,8 @@
+package com.basistheory.android.constants;
+
+public enum ElementValueType {
+    INTEGER,
+    DOUBLE,
+    STRING,
+    BOOLEAN
+}

--- a/lib/src/main/java/com/basistheory/android/model/ElementValueReference.kt
+++ b/lib/src/main/java/com/basistheory/android/model/ElementValueReference.kt
@@ -1,13 +1,20 @@
 package com.basistheory.android.model
 
+import com.basistheory.android.constants.ElementValueType
 import com.basistheory.android.model.exceptions.IncompleteElementException
 import com.basistheory.android.view.TextElement
 
 class ElementValueReference(private val valueGetter: () -> String?) {
     private var _element: TextElement? = null
+    private var _getValueType: ElementValueType? = ElementValueType.STRING;
 
-    constructor(element: TextElement, valueGetter: () -> String?) : this(valueGetter) {
+    constructor(
+        element: TextElement,
+        valueGetter: () -> String?,
+        getValueType: ElementValueType?
+    ) : this(valueGetter) {
         _element = element
+        _getValueType = getValueType
     }
 
     internal fun getValue(): String? {
@@ -16,4 +23,7 @@ class ElementValueReference(private val valueGetter: () -> String?) {
 
         return valueGetter()
     }
+
+    var getValueType: ElementValueType? = ElementValueType.STRING
+        get() = _getValueType
 }

--- a/lib/src/main/java/com/basistheory/android/model/ElementValueReference.kt
+++ b/lib/src/main/java/com/basistheory/android/model/ElementValueReference.kt
@@ -6,7 +6,7 @@ import com.basistheory.android.view.TextElement
 
 class ElementValueReference(private val valueGetter: () -> String?) {
     private var _element: TextElement? = null
-    private var _getValueType: ElementValueType? = ElementValueType.STRING;
+    private var _getValueType: ElementValueType = ElementValueType.STRING;
 
     constructor(
         element: TextElement,
@@ -14,7 +14,7 @@ class ElementValueReference(private val valueGetter: () -> String?) {
         getValueType: ElementValueType?
     ) : this(valueGetter) {
         _element = element
-        _getValueType = getValueType
+        _getValueType = getValueType ?: ElementValueType.STRING
     }
 
     internal fun getValue(): String? {
@@ -24,6 +24,6 @@ class ElementValueReference(private val valueGetter: () -> String?) {
         return valueGetter()
     }
 
-    var getValueType: ElementValueType? = ElementValueType.STRING
+    var getValueType: ElementValueType = ElementValueType.STRING
         get() = _getValueType
 }

--- a/lib/src/main/java/com/basistheory/android/service/BasisTheoryElements.kt
+++ b/lib/src/main/java/com/basistheory/android/service/BasisTheoryElements.kt
@@ -5,6 +5,7 @@ import com.basistheory.CreateSessionResponse
 import com.basistheory.CreateTokenRequest
 import com.basistheory.CreateTokenResponse
 import com.basistheory.Token
+import com.basistheory.android.constants.ElementValueType
 import com.basistheory.android.model.ElementValueReference
 import com.basistheory.android.util.*
 import com.basistheory.android.util.getElementsValues
@@ -41,8 +42,8 @@ class BasisTheoryElements internal constructor(
             val data =
                 if (createTokenRequest.data == null) null
                 else if (createTokenRequest.data!!::class.java.isPrimitiveType()) createTokenRequest.data
-                else if (createTokenRequest.data is TextElement) (createTokenRequest.data as TextElement).tryGetTextToTokenize()
-                else if (createTokenRequest.data is ElementValueReference) (createTokenRequest.data as ElementValueReference).getValue()
+                else if (createTokenRequest.data is TextElement) (createTokenRequest.data as TextElement).tryGetTextToTokenize().toValueType((createTokenRequest.data as TextElement).getValueType)
+                else if (createTokenRequest.data is ElementValueReference) (createTokenRequest.data as ElementValueReference).getValue().toValueType((createTokenRequest.data as ElementValueReference).getValueType)
                 else replaceElementRefs(createTokenRequest.data!!.toMap())
 
             createTokenRequest.data = data
@@ -73,6 +74,26 @@ class BasisTheoryElements internal constructor(
     companion object {
         @JvmStatic
         fun builder(): BasisTheoryElementsBuilder = BasisTheoryElementsBuilder()
+    }
+}
+
+fun String?.toValueType(getValueType: ElementValueType?): Any? {
+    return when(getValueType) {
+        ElementValueType.INTEGER -> {
+            this?.toInt()
+        }
+
+        ElementValueType.DOUBLE -> {
+            this?.toDouble()
+        }
+
+        ElementValueType.BOOLEAN -> {
+            this?.toBoolean()
+        }
+
+        else -> {
+            this;
+        }
     }
 }
 

--- a/lib/src/main/java/com/basistheory/android/util/DataManipulationUtils.kt
+++ b/lib/src/main/java/com/basistheory/android/util/DataManipulationUtils.kt
@@ -2,6 +2,7 @@ package com.basistheory.android.util
 
 import com.basistheory.android.model.ElementValueReference
 import com.basistheory.android.model.exceptions.IncompleteElementException
+import com.basistheory.android.service.toValueType
 import com.basistheory.android.view.TextElement
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody
@@ -41,8 +42,8 @@ internal fun replaceElementRefs(value: Any?): Any? {
         }
     } else {
         when (value) {
-            is TextElement -> value.tryGetTextToTokenize()
-            is ElementValueReference -> value.getValue()
+            is TextElement -> value.tryGetTextToTokenize().toValueType(value.getValueType)
+            is ElementValueReference -> value.getValue().toValueType(value.getValueType)
             else -> {
                 val children =
                     if (value as? MutableMap<String, Any?> != null) value.toMutableMap() else value.toMap()
@@ -71,8 +72,8 @@ internal fun getElementsValues(body: Any) =
     body.let {
         when {
             it::class.java.isPrimitiveType() -> it.toString()
-            it is TextElement -> it.getTransformedText()
-            it is ElementValueReference -> it.getValue()
+            it is TextElement -> it.getTransformedText().toValueType(it.getValueType)
+            it is ElementValueReference -> it.getValue().toValueType(it.getValueType)
             else -> replaceElementRefs(it.toMap())
         }
     }

--- a/lib/src/main/java/com/basistheory/android/view/CardExpirationDateElement.kt
+++ b/lib/src/main/java/com/basistheory/android/view/CardExpirationDateElement.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Build
 import android.util.AttributeSet
 import androidx.annotation.RequiresApi
+import com.basistheory.android.constants.ElementValueType
 import com.basistheory.android.model.ElementValueReference
 import com.basistheory.android.model.InputType
 import com.basistheory.android.view.mask.ElementMask
@@ -18,11 +19,14 @@ class CardExpirationDateElement @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : TextElement(context, attrs, defStyleAttr) {
 
-    fun month(): ElementValueReference = ElementValueReference(this, ::getMonthValue)
+    fun month(): ElementValueReference =
+        ElementValueReference(this, ::getMonthValue, ElementValueType.INTEGER)
 
-    fun year(): ElementValueReference = ElementValueReference(this, ::getYearValue)
+    fun year(): ElementValueReference =
+        ElementValueReference(this, ::getYearValue, ElementValueType.INTEGER)
 
-    fun format(dateFormat: String): ElementValueReference = ElementValueReference(this, getFormattedValue(dateFormat))
+    fun format(dateFormat: String): ElementValueReference =
+        ElementValueReference(this, getFormattedValue(dateFormat), getValueType)
 
     fun setValueRef(
         monthRef: ElementValueReference,

--- a/lib/src/main/java/com/basistheory/android/view/TextElement.kt
+++ b/lib/src/main/java/com/basistheory/android/view/TextElement.kt
@@ -19,6 +19,7 @@ import android.widget.FrameLayout
 import androidx.appcompat.widget.AppCompatEditText
 import androidx.core.os.bundleOf
 import com.basistheory.android.R
+import com.basistheory.android.constants.ElementValueType
 import com.basistheory.android.event.BlurEvent
 import com.basistheory.android.event.ChangeEvent
 import com.basistheory.android.event.ElementEventListeners
@@ -45,6 +46,7 @@ open class TextElement @JvmOverloads constructor(
     private var _isMaskSatisfied: Boolean = true
     private var _isEmpty: Boolean = true
     private var _inputType: InputType = InputType.TEXT
+    private var _getValueType: ElementValueType = ElementValueType.STRING;
 
     internal var inputAction: InputAction = InputAction.INSERT
 
@@ -207,6 +209,12 @@ open class TextElement @JvmOverloads constructor(
 
             if (value.isConcealed)
                 _editText.transformationMethod = FullyHiddenTransformationMethod()
+        }
+
+    var getValueType: ElementValueType
+        get() = _getValueType
+        set(value) {
+            _getValueType = value
         }
 
     var removeDefaultStyles: Boolean

--- a/lib/src/main/java/com/basistheory/android/view/TextElement.kt
+++ b/lib/src/main/java/com/basistheory/android/view/TextElement.kt
@@ -10,6 +10,7 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.util.AttributeSet
 import android.util.TypedValue
+import android.view.Gravity
 import android.view.View.OnFocusChangeListener
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
@@ -81,6 +82,8 @@ open class TextElement @JvmOverloads constructor(
                         getInt(R.styleable.TextElement_android_typeface, 0),
                         defStyleAttr
                     )
+
+                    gravity = Gravity.START
 
                     // map custom attributes
                     mask = getString(R.styleable.TextElement_bt_mask)?.let { ElementMask(it) }
@@ -176,6 +179,12 @@ open class TextElement @JvmOverloads constructor(
         get() = _editText.typeface
         set(value) {
             _editText.typeface = value
+        }
+
+    var gravity: Int
+        get() = _editText.gravity
+        set(value) {
+            _editText.gravity = value
         }
 
     var hint: CharSequence?

--- a/lib/src/main/res/values/attrs.xml
+++ b/lib/src/main/res/values/attrs.xml
@@ -9,6 +9,7 @@
         <attr name="android:textSize" />
         <attr name="android:textColorHint" />
         <attr name="android:typeface" />
+        <attr name="android:gravity" />
 
         <attr name="bt_mask" format="string" />
         <attr name="bt_removeDefaultStyles" format="boolean" />

--- a/lib/src/test/java/com/basistheory/android/service/BasisTheoryElementsTests.kt
+++ b/lib/src/test/java/com/basistheory/android/service/BasisTheoryElementsTests.kt
@@ -268,10 +268,10 @@ class BasisTheoryElementsTests {
             cardExpElement.setText("$month/${year.takeLast(2)}")
 
             bt.tokenize(cardExpElement.month())
-            verify { tokenizeApi.tokenize(month) }
+            verify { tokenizeApi.tokenize(expDate.monthValue) }
 
             bt.tokenize(cardExpElement.year())
-            verify { tokenizeApi.tokenize(year) }
+            verify { tokenizeApi.tokenize(expDate.year) }
 
             bt.tokenize(cardExpElement.format("MM"))
             verify { tokenizeApi.tokenize(month) }
@@ -359,8 +359,8 @@ class BasisTheoryElementsTests {
                     "name" to name,
                     "card" to mapOf(
                         "number" to cardNumber.replace(Regex("""[^\d]"""), ""),
-                        "expMonth" to expMonth,
-                        "expYear" to expYear,
+                        "expMonth" to expDate.monthValue,
+                        "expYear" to expDate.year,
                         "cvc" to cvc
                     ),
                     "nested" to mapOf(
@@ -557,12 +557,12 @@ class BasisTheoryElementsTests {
 
             bt.createToken(createTokenRequestMonth)
 
-            val expectedMonthRequest = createTokenRequest(month)
+            val expectedMonthRequest = createTokenRequest(expDate.monthValue)
             verify { tokensApi.create(expectedMonthRequest) }
 
             bt.createToken(createTokenRequestYear)
 
-            val expectedYearRequest = createTokenRequest(year)
+            val expectedYearRequest = createTokenRequest(expDate.year)
             verify { tokensApi.create(expectedYearRequest) }
         }
 
@@ -621,8 +621,8 @@ class BasisTheoryElementsTests {
                     "name" to name,
                     "card" to mapOf(
                         "number" to cardNumber.replace(Regex("""[^\d]"""), ""),
-                        "expMonth" to expMonth,
-                        "expYear" to expYear,
+                        "expMonth" to expDate.monthValue,
+                        "expYear" to expDate.year,
                         "cvc" to cvc
                     ),
                     "nested" to mapOf(
@@ -643,7 +643,7 @@ class BasisTheoryElementsTests {
         }
 
     @Test
-    fun `create token should respect getValueType type when sending values to the API`() = runBlocking {
+    fun `createToken should respect getValueType type when sending values to the API`() = runBlocking {
         every { provider.getTokensApi(any()) } returns tokensApi
 
         val testString = faker.name().firstName()


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

Adds the `getValueType` option for converting element value types before sending to API.

⚠️ BREAKING CHANGE:

The `month` and `year` methods of `CardExpirationDateElement` will now send `Int` values to the API.
This will cause any tokenization response w/ these values to also return `Int`.

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
