### PR TITLE
eng-6913 fix android gravity center display

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -53,27 +53,27 @@ jobs:
       - name: Setup Gradle cache
         uses: gradle/gradle-build-action@v2.4.2
 
-      - name: Setup AVD cache
-        uses: actions/cache@v3
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
+#      - name: Setup AVD cache
+#        uses: actions/cache@v3
+#        id: avd-cache
+#        with:
+#          path: |
+#            ~/.android/avd/*
+#            ~/.android/adb*
+#          key: avd-${{ matrix.api-level }}
 
-      - name: Create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          force-avd-creation: true
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
-          target: default
-          arch: x86_64
-          profile: pixel_3a
-          script: echo "Generated AVD snapshot for caching."
+#      - name: Create AVD and generate snapshot for caching
+#        if: steps.avd-cache.outputs.cache-hit != 'true'
+#        uses: reactivecircus/android-emulator-runner@v2
+#        with:
+#          api-level: ${{ matrix.api-level }}
+#          force-avd-creation: true
+#          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+#          disable-animations: false
+#          target: default
+#          arch: x86_64
+#          profile: pixel_3a
+#          script: echo "Generated AVD snapshot for caching."
 
       - name: Run tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/README.md
+++ b/README.md
@@ -99,3 +99,4 @@ Click [here](https://portal.basistheory.com/applications/create?permissions=toke
 to create one in the Basis Theory portal.
 
 A full example Android app is included within the [example](example) module within this repo.
+

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -25,7 +25,6 @@ android {
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            signingConfig signingConfigs.debug
         }
     }
     compileOptions {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -25,6 +25,7 @@ android {
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.debug
         }
     }
     compileOptions {

--- a/example/src/main/java/com/basistheory/android/example/view/social_security_number/SocialSecurityNumberFragment.kt
+++ b/example/src/main/java/com/basistheory/android/example/view/social_security_number/SocialSecurityNumberFragment.kt
@@ -5,7 +5,6 @@ import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.appcompat.widget.AppCompatEditText
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.basistheory.android.example.databinding.FragmentSocialSecurityNumberBinding
@@ -33,8 +32,6 @@ class SocialSecurityNumberFragment : Fragment() {
 
         binding.socialSecurityNumber.inputType = InputType.NUMBER
         binding.socialSecurityNumber.gravity = Gravity.CENTER
-
-        println((binding.socialSecurityNumber.getChildAt(0) as AppCompatEditText).text)
 
         return binding.root
     }

--- a/example/src/main/java/com/basistheory/android/example/view/social_security_number/SocialSecurityNumberFragment.kt
+++ b/example/src/main/java/com/basistheory/android/example/view/social_security_number/SocialSecurityNumberFragment.kt
@@ -1,14 +1,17 @@
 package com.basistheory.android.example.view.social_security_number
 
 import android.os.Bundle
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.widget.AppCompatEditText
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.basistheory.android.example.databinding.FragmentSocialSecurityNumberBinding
 import com.basistheory.android.example.util.tokenExpirationTimestamp
 import com.basistheory.android.example.viewmodel.ApiViewModel
+import com.basistheory.android.model.InputType
 
 class SocialSecurityNumberFragment : Fragment() {
     private val binding: FragmentSocialSecurityNumberBinding by lazy {
@@ -27,6 +30,11 @@ class SocialSecurityNumberFragment : Fragment() {
 
         binding.tokenizeButton.setOnClickListener { tokenize() }
         binding.autofillButton.setOnClickListener { autofill() }
+
+        binding.socialSecurityNumber.inputType = InputType.NUMBER
+        binding.socialSecurityNumber.gravity = Gravity.CENTER
+
+        println((binding.socialSecurityNumber.getChildAt(0) as AppCompatEditText).text)
 
         return binding.root
     }

--- a/example/src/main/res/layout/fragment_social_security_number.xml
+++ b/example/src/main/res/layout/fragment_social_security_number.xml
@@ -31,7 +31,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:background="@drawable/rounded_edit_text"
-                    android:inputType="number"
                     android:padding="5dp"
                     android:hint="@string/social_security_number"
                     android:textColor="@color/gray_800"

--- a/lib/src/main/java/com/basistheory/android/view/SensitiveEditText.kt
+++ b/lib/src/main/java/com/basistheory/android/view/SensitiveEditText.kt
@@ -2,7 +2,6 @@ package com.basistheory.android.view
 
 import android.content.Context
 import android.text.Editable
-import android.text.SpannableString
 import android.text.SpannableStringBuilder
 import android.text.TextWatcher
 import androidx.appcompat.widget.AppCompatEditText
@@ -17,7 +16,7 @@ internal class SensitiveEditText(
 
 
     override fun addTextChangedListener(watcher: TextWatcher?) {
-        if (allowTextAccess) {
+        if (allowTextAccess || BuildConfig.DEBUG) {
             super.addTextChangedListener(watcher)
         }
     }
@@ -26,17 +25,15 @@ internal class SensitiveEditText(
         val stackTrace = Thread.currentThread().stackTrace
         val indexOfBtEditText =
             stackTrace.indexOfLast { e -> e.className == "com.basistheory.android.view.SensitiveEditText" }
-        val isInternalInvocation = stackTrace[indexOfBtEditText + 1].className.startsWith("android.widget")
-                || stackTrace[indexOfBtEditText + 1].className.startsWith("android.view")
+        val isInternalInvocation =
+            stackTrace[indexOfBtEditText + 1].className.startsWith("android.widget.") || stackTrace[indexOfBtEditText + 1].className.startsWith(
+                "android.view."
+            )
 
         val text = super.getText()
-        println("actual text: $text")
-        return if (allowTextAccess || text.isNullOrBlank() || isInternalInvocation) {
-            println("returning actual text")
+        return if (allowTextAccess || text.isNullOrBlank() || isInternalInvocation || BuildConfig.DEBUG) {
             text
-        }
-        else {
-            println("returning masked text:${"*".repeat(text.length)}")
+        } else {
             SpannableStringBuilder("*".repeat(text.length))
         }
     }

--- a/lib/src/main/java/com/basistheory/android/view/SensitiveEditText.kt
+++ b/lib/src/main/java/com/basistheory/android/view/SensitiveEditText.kt
@@ -35,7 +35,7 @@ internal class SensitiveEditText(
         } catch (_: Exception) { }
 
         val text = super.getText()
-        return if (allowTextAccess || text.isNullOrBlank() || isInternalInvocation) {
+        return if (allowTextAccess || text.isNullOrBlank() || isInternalInvocation || BuildConfig.DEBUG) {
             text
         } else {
             SpannableStringBuilder("*".repeat(text.length))

--- a/lib/src/main/java/com/basistheory/android/view/SensitiveEditText.kt
+++ b/lib/src/main/java/com/basistheory/android/view/SensitiveEditText.kt
@@ -6,6 +6,7 @@ import android.text.SpannableStringBuilder
 import android.text.TextWatcher
 import androidx.appcompat.widget.AppCompatEditText
 import com.basistheory.android.BuildConfig
+import java.lang.Exception
 
 internal class SensitiveEditText(
     context: Context
@@ -22,16 +23,19 @@ internal class SensitiveEditText(
     }
 
     override fun getText(): Editable? {
-        val stackTrace = Thread.currentThread().stackTrace
-        val indexOfBtEditText =
-            stackTrace.indexOfLast { e -> e.className == "com.basistheory.android.view.SensitiveEditText" }
-        val isInternalInvocation =
-            stackTrace[indexOfBtEditText + 1].className.startsWith("android.widget.") || stackTrace[indexOfBtEditText + 1].className.startsWith(
-                "android.view."
-            )
+        var isInternalInvocation: Boolean = false
+        try {
+            val stackTrace = Thread.currentThread().stackTrace
+            val indexOfBtEditText =
+                stackTrace.indexOfLast { e -> e.className == "com.basistheory.android.view.SensitiveEditText" }
+            isInternalInvocation =
+                stackTrace[indexOfBtEditText + 1].className.startsWith("android.widget.") || stackTrace[indexOfBtEditText + 1].className.startsWith(
+                    "android.view."
+                )
+        } catch (_: Exception) { }
 
         val text = super.getText()
-        return if (allowTextAccess || text.isNullOrBlank() || isInternalInvocation || BuildConfig.DEBUG) {
+        return if (allowTextAccess || text.isNullOrBlank() || isInternalInvocation) {
             text
         } else {
             SpannableStringBuilder("*".repeat(text.length))

--- a/lib/src/main/java/com/basistheory/android/view/SensitiveEditText.kt
+++ b/lib/src/main/java/com/basistheory/android/view/SensitiveEditText.kt
@@ -16,14 +16,33 @@ internal class SensitiveEditText(
 
 
     override fun addTextChangedListener(watcher: TextWatcher?) {
-        if (allowTextAccess || BuildConfig.DEBUG) {
+        if (allowTextAccess) {
             super.addTextChangedListener(watcher)
         }
     }
 
     override fun getText(): Editable? {
-        return if (allowTextAccess || BuildConfig.DEBUG)
-            super.getText()
-        else SpannableStringBuilder()
+        val text = super.getText()
+        println("actual text: $text")
+        return if (allowTextAccess || text.isNullOrBlank()) {
+            println("returning actual text")
+            text
+        }
+        else {
+            println("returning masked text:${"*".repeat(text.length)}")
+            SpannableStringBuilder("*".repeat(text.length))
+        }
     }
+
+//    override fun getText(): Editable? {
+//        val stackTrace = Thread.currentThread().stackTrace
+//        val indexOfBtEditText =
+//            stackTrace.indexOfLast { e -> e.className == "com.basistheory.android.view.SensitiveEditText" }
+//        val isInternalInvocation = stackTrace[indexOfBtEditText + 1].className.startsWith("android.widget")
+//                || stackTrace[indexOfBtEditText + 1].className.startsWith("android.view")
+//
+//        return if (allowTextAccess || isInternalInvocation)
+//            super.getText()
+//        else SpannableStringBuilder("*****")
+//    }
 }

--- a/lib/src/main/java/com/basistheory/android/view/SensitiveEditText.kt
+++ b/lib/src/main/java/com/basistheory/android/view/SensitiveEditText.kt
@@ -2,6 +2,7 @@ package com.basistheory.android.view
 
 import android.content.Context
 import android.text.Editable
+import android.text.SpannableString
 import android.text.SpannableStringBuilder
 import android.text.TextWatcher
 import androidx.appcompat.widget.AppCompatEditText
@@ -22,9 +23,15 @@ internal class SensitiveEditText(
     }
 
     override fun getText(): Editable? {
+        val stackTrace = Thread.currentThread().stackTrace
+        val indexOfBtEditText =
+            stackTrace.indexOfLast { e -> e.className == "com.basistheory.android.view.SensitiveEditText" }
+        val isInternalInvocation = stackTrace[indexOfBtEditText + 1].className.startsWith("android.widget")
+                || stackTrace[indexOfBtEditText + 1].className.startsWith("android.view")
+
         val text = super.getText()
         println("actual text: $text")
-        return if (allowTextAccess || text.isNullOrBlank()) {
+        return if (allowTextAccess || text.isNullOrBlank() || isInternalInvocation) {
             println("returning actual text")
             text
         }
@@ -33,16 +40,4 @@ internal class SensitiveEditText(
             SpannableStringBuilder("*".repeat(text.length))
         }
     }
-
-//    override fun getText(): Editable? {
-//        val stackTrace = Thread.currentThread().stackTrace
-//        val indexOfBtEditText =
-//            stackTrace.indexOfLast { e -> e.className == "com.basistheory.android.view.SensitiveEditText" }
-//        val isInternalInvocation = stackTrace[indexOfBtEditText + 1].className.startsWith("android.widget")
-//                || stackTrace[indexOfBtEditText + 1].className.startsWith("android.view")
-//
-//        return if (allowTextAccess || isInternalInvocation)
-//            super.getText()
-//        else SpannableStringBuilder("*****")
-//    }
 }


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Fixes an issue with the recent vulnerability fix in which setting the text element to gravity center was making the display
- disappear. 
- Fixes an issue in which the cursor would disappear after typing or autofilling

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
